### PR TITLE
Pa 69/feat/back/lead contact history

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/mongoose": "^11.0.3",
         "@nestjs/platform-express": "^10.4.17",
-        "@nestjs/swagger": "^7.3.1",
+        "@nestjs/swagger": "^8.1.1",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -1817,9 +1817,9 @@
       }
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
-      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -2237,17 +2237,17 @@
       "license": "MIT"
     },
     "node_modules/@nestjs/swagger": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.3.1.tgz",
-      "integrity": "sha512-LUC4mr+5oAleEC/a2j8pNRh1S5xhKXJ1Gal5ZdRjt9XebQgbngXCdW7JTA9WOEcwGtFZN9EnKYdquzH971LZfw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.1.1.tgz",
+      "integrity": "sha512-5Mda7H1DKnhKtlsb0C7PYshcvILv8UFyUotHzxmWh0G65Z21R3LZH/J8wmpnlzL4bmXIfr42YwbEwRxgzpJ5sQ==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/tsdoc": "^0.14.2",
-        "@nestjs/mapped-types": "2.0.5",
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.6",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
-        "path-to-regexp": "3.2.0",
-        "swagger-ui-dist": "5.11.2"
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.18.2"
       },
       "peerDependencies": {
         "@fastify/static": "^6.0.0 || ^7.0.0",
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
-      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
@@ -2289,17 +2289,14 @@
         }
       }
     },
-    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
-      "license": "MIT"
-    },
     "node_modules/@nestjs/swagger/node_modules/swagger-ui-dist": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
-      "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A==",
-      "license": "Apache-2.0"
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.17",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/mongoose": "^11.0.3",
     "@nestjs/platform-express": "^10.4.17",
-    "@nestjs/swagger": "^7.3.1",
+    "@nestjs/swagger": "^8.1.1",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { MailModule } from './mail/mail.module';
 import { ResourcesModule } from './resources/resources.module';
 import configuration from './config/configuration';
 import { CloudinaryModule } from './cloudinary/cloudinary.module';
+import { EngagementsModule } from './engagements/engagements.module';
 
 @Module({
   imports: [
@@ -17,13 +18,14 @@ import { CloudinaryModule } from './cloudinary/cloudinary.module';
       isGlobal: true,
       load: [configuration],
     }),
-    MongooseModule.forRoot(process.env.MONGODB_URI), 
+    MongooseModule.forRoot(process.env.MONGODB_URI),
     LeadsModule,
     AuthModule,
     UsersModule,
     MailModule,
     ResourcesModule,
     CloudinaryModule,
+    EngagementsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/dtos/pagination.dto.ts
+++ b/backend/src/common/dtos/pagination.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationResponseDto<T> {
+  @ApiProperty()
+  data: T[];
+  @ApiProperty()
+  current_page: number;
+  @ApiProperty()
+  next_page: number;
+  @ApiProperty()
+  prev_page: number;
+  @ApiProperty()
+  last_page: number;
+  @ApiProperty()
+  total_records: number;
+  @ApiProperty()
+  page_records: number;
+  @ApiProperty()
+  urls?: {
+    next: string;
+    prev: string;
+    last: string;
+    first: string;
+  };
+}
+
+export class QueryPaginationDto {
+  @ApiProperty({
+    required: false,
+    type: Number,
+    description: 'Número de página',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(999)
+  page?: number;
+
+  @ApiProperty({
+    required: false,
+    type: Number,
+    description: 'Límite de resultados por página',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  take?: number;
+}

--- a/backend/src/engagements/dto/generate-engagement.dto.ts
+++ b/backend/src/engagements/dto/generate-engagement.dto.ts
@@ -70,4 +70,7 @@ export class GenerateEngagementDto {
   @MinLength(2)
   @MaxLength(512)
   response?: string;
+  @IsOptional()
+  @IsString()
+  created_by?: string = 'system';
 }

--- a/backend/src/engagements/dto/generate-engagement.dto.ts
+++ b/backend/src/engagements/dto/generate-engagement.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsString,
+  IsOptional,
+  IsDate,
+  MinLength,
+  MaxLength,
+  IsIn,
+  IsMongoId,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { LEAD_CONTACT_TYPES } from '../engagements.constants';
+
+export class GenerateEngagementDto {
+  @ApiProperty({
+    required: true,
+    type: 'string',
+  })
+  @IsString()
+  @IsMongoId()
+  lead_id: string;
+
+  @ApiProperty({
+    required: true,
+    enum: LEAD_CONTACT_TYPES,
+  })
+  @IsIn(LEAD_CONTACT_TYPES)
+  contact_type: (typeof LEAD_CONTACT_TYPES)[number];
+
+  @ApiProperty({
+    required: true,
+    type: 'string',
+    example: '1/1/2025',
+  })
+  @IsDate()
+  @Type(() => Date)
+  contact_date: Date;
+
+  @ApiProperty({
+    required: false,
+    type: 'string',
+    maxLength: 256,
+    minLength: 2,
+  })
+  @IsString()
+  @IsOptional()
+  @MinLength(2)
+  @MaxLength(256)
+  subject?: string;
+
+  @ApiProperty({
+    required: true,
+    type: 'string',
+    maxLength: 256,
+    minLength: 2,
+  })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(256)
+  detail: string;
+
+  @ApiProperty({
+    required: false,
+    type: 'string',
+    maxLength: 256,
+    minLength: 2,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(512)
+  response?: string;
+}

--- a/backend/src/engagements/dto/response-engagement.dto.ts
+++ b/backend/src/engagements/dto/response-engagement.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose, Transform } from 'class-transformer';
+import { Leads } from '../../leads/schema/leads.model';
+
+export class EngagementResponseDto {
+  @ApiProperty()
+  @Expose({ name: 'id' })
+  @Transform(({ obj }) => obj._id.toString())
+  id: string;
+
+  @ApiProperty()
+  @Expose({ name: 'lead_id' })
+  @Transform(({ obj }) => obj.lead.toString())
+  lead_id: string;
+
+  @ApiProperty()
+  @Expose()
+  contact_type: string;
+
+  @ApiProperty()
+  @Expose()
+  contact_date: Date;
+
+  @ApiProperty()
+  @Expose()
+  subject: string;
+
+  @ApiProperty()
+  @Expose()
+  detail: string;
+
+  @ApiProperty()
+  @Expose()
+  response?: string;
+
+  @ApiProperty()
+  @Expose()
+  updated_by?: string;
+
+  @ApiProperty()
+  @Expose()
+  created_by: string;
+
+  @Exclude()
+  lead: Leads;
+
+  @Exclude()
+  __v: number;
+}

--- a/backend/src/engagements/dto/response-engagement.dto.ts
+++ b/backend/src/engagements/dto/response-engagement.dto.ts
@@ -41,6 +41,16 @@ export class EngagementResponseDto {
   @Expose()
   created_by: string;
 
+  @ApiProperty()
+  @Expose()
+  @Transform(({ obj }) => obj.createdAt.toISOString())
+  created_at: Date;
+
+  @ApiProperty()
+  @Expose()
+  @Transform(({ obj }) => obj.updatedAt.toISOString())
+  updated_at: Date;
+
   @Exclude()
   lead: Leads;
 

--- a/backend/src/engagements/dto/response-engagement.dto.ts
+++ b/backend/src/engagements/dto/response-engagement.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Transform } from 'class-transformer';
 import { Leads } from '../../leads/schema/leads.model';
+import { PaginationResponseDto } from 'src/common/dtos/pagination.dto';
 
 export class EngagementResponseDto {
   @ApiProperty()
@@ -43,12 +44,16 @@ export class EngagementResponseDto {
 
   @ApiProperty()
   @Expose()
-  @Transform(({ obj }) => obj.createdAt.toISOString())
+  @Transform(({ obj }) =>
+    obj.createdAt ? obj.createdAt.toISOString() : new Date(),
+  )
   created_at: Date;
 
   @ApiProperty()
   @Expose()
-  @Transform(({ obj }) => obj.updatedAt.toISOString())
+  @Transform(({ obj }) =>
+    obj.createdAt ? obj.createdAt.toISOString() : new Date(),
+  )
   updated_at: Date;
 
   @Exclude()
@@ -56,4 +61,9 @@ export class EngagementResponseDto {
 
   @Exclude()
   __v: number;
+}
+
+export class EngagementPaginationDto extends PaginationResponseDto<EngagementResponseDto> {
+  @ApiProperty({ type: EngagementResponseDto, isArray: true })
+  data: EngagementResponseDto[];
 }

--- a/backend/src/engagements/dto/update-engagement.dto.ts
+++ b/backend/src/engagements/dto/update-engagement.dto.ts
@@ -1,0 +1,23 @@
+import { OmitType, PartialType, PickType } from '@nestjs/mapped-types';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+import { GenerateEngagementDto } from './generate-engagement.dto';
+
+export class UpdateEngagementDto extends PartialType(
+  OmitType(GenerateEngagementDto, ['lead_id'] as const),
+) {}
+
+export class ResponseEngagementDto extends PickType(GenerateEngagementDto, [
+  'response',
+]) {
+  @ApiProperty({
+    required: true,
+    type: 'string',
+    maxLength: 256,
+    minLength: 2,
+  })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(512)
+  response: string;
+}

--- a/backend/src/engagements/engagement.service.spec.ts
+++ b/backend/src/engagements/engagement.service.spec.ts
@@ -1,0 +1,115 @@
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { EngagementService } from './engagements.service';
+import { EngagementsRepository } from './engagements.repository';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+import { LeadsService } from '../leads/leads.service';
+
+describe('Engagements Service', () => {
+  let service: EngagementService;
+  let repository: EngagementsRepository;
+  let leadsService: LeadsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EngagementService,
+        {
+          provide: EngagementsRepository,
+          useValue: {
+            createEngagement: jest.fn(),
+            findEngagement: jest.fn(),
+          },
+        },
+        {
+          provide: LeadsService,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<EngagementService>(EngagementService);
+    repository = module.get<EngagementsRepository>(EngagementsRepository);
+    leadsService = module.get<LeadsService>(LeadsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should throw internal server error at MongoError', async () => {
+    jest.spyOn(repository, 'findEngagement').mockRejectedValueOnce(new Error());
+
+    await expect(service.getEngagement('id')).rejects.toThrow(
+      new InternalServerErrorException(),
+    );
+  });
+
+  it('should throw NotFoundException at non existing Engagement', async () => {
+    jest.spyOn(repository, 'findEngagement').mockResolvedValueOnce(null);
+    await expect(service.getEngagement('id')).rejects.toThrow(
+      new NotFoundException('Engagement not found'),
+    );
+  });
+
+  describe('generateLeadHistoryItem', () => {
+    const date = new Date();
+    const dto: GenerateEngagementDto = {
+      contact_date: date,
+      contact_type: 'email',
+      lead_id: '1',
+      subject: 'Subject',
+      detail: 'asdasd',
+    };
+    it('should successfully create a lead history item', async () => {
+      const engagement = {
+        contact_date: date,
+        contact_type: 'email_@',
+        subject: 'Subject',
+        lead: {
+          __id: '',
+          fullname: '',
+          company: '',
+          phone: '',
+          email: '',
+          service: '',
+          message: '',
+          status: '',
+          contact_id: {},
+          origen: '',
+        },
+        detail: 'asdasdp',
+        created_by: 'system',
+      };
+
+      jest.spyOn(repository, 'createEngagement').mockResolvedValue(engagement);
+
+      const result = await service.generateEngagement(dto);
+      expect(result).toEqual(engagement);
+      expect(repository.createEngagement).toHaveBeenCalledWith(dto);
+    });
+
+    it('should throw InternalServerError on error', async () => {
+      jest.spyOn(repository, 'createEngagement').mockRejectedValue(new Error());
+
+      await expect(service.generateEngagement(dto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('should throw NotFoundException on non existing Lead', async () => {
+      jest
+        .spyOn(leadsService, 'findById')
+        .mockRejectedValueOnce(new NotFoundException());
+
+      await expect(service.generateEngagement(dto)).rejects.toThrow(
+        new NotFoundException('Lead not found'),
+      );
+    });
+  });
+});

--- a/backend/src/engagements/engagements.constants.ts
+++ b/backend/src/engagements/engagements.constants.ts
@@ -1,0 +1,7 @@
+export const LEAD_CONTACT_TYPES = [
+  'email',
+  'website',
+  'phonecall',
+  'whatsapp',
+  'other',
+] as const;

--- a/backend/src/engagements/engagements.controller.ts
+++ b/backend/src/engagements/engagements.controller.ts
@@ -30,6 +30,7 @@ export class EngagementsController {
     return this._service.getEngagement(itemId);
   }
 
+  //TODO: add UserId to creation
   @Post('')
   @ApiCreatedResponse({ type: EngagementResponseDto })
   createEngagementItem(@Body() dto: GenerateEngagementDto) {

--- a/backend/src/engagements/engagements.controller.ts
+++ b/backend/src/engagements/engagements.controller.ts
@@ -1,10 +1,14 @@
-import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { EngagementService } from './engagements.service';
 import { GenerateEngagementDto } from './dto/generate-engagement.dto';
 import { ResponseEngagementDto } from './dto/update-engagement.dto';
-import { EngagementResponseDto } from './dto/response-engagement.dto';
+import {
+  EngagementPaginationDto,
+  EngagementResponseDto,
+} from './dto/response-engagement.dto';
 import { MongoIdValidationPipe } from 'src/common/pipes/isMongoIdValidation.pipe';
+import { QueryPaginationDto } from 'src/common/dtos/pagination.dto';
 
 @ApiTags('Engagements')
 @Controller('/api/engagements')
@@ -12,11 +16,12 @@ export class EngagementsController {
   constructor(private readonly _service: EngagementService) {}
 
   @Get('lead/:leadId')
-  @ApiOkResponse({ type: [EngagementResponseDto] })
+  @ApiOkResponse({ type: EngagementPaginationDto })
   getEngagementsByLeadId(
     @Param('leadId', MongoIdValidationPipe) leadId: string,
+    @Query() pag: QueryPaginationDto,
   ) {
-    return this._service.getEngagementsByLeadId(leadId);
+    return this._service.getEngagementsByLeadId(leadId, pag.take, pag.page);
   }
 
   @Get(':itemId')

--- a/backend/src/engagements/engagements.controller.ts
+++ b/backend/src/engagements/engagements.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { EngagementService } from './engagements.service';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+import { ResponseEngagementDto } from './dto/update-engagement.dto';
+import { EngagementResponseDto } from './dto/response-engagement.dto';
+import { MongoIdValidationPipe } from 'src/common/pipes/isMongoIdValidation.pipe';
+
+@ApiTags('Engagements')
+@Controller('/api/engagements')
+export class EngagementsController {
+  constructor(private readonly _service: EngagementService) {}
+
+  @Get('lead/:leadId')
+  getEngagementsByid(@Param('leadId', MongoIdValidationPipe) leadId: string) {
+    return this._service.getEngagements(leadId);
+  }
+
+  @Get(':itemId')
+  @ApiOkResponse({ type: EngagementResponseDto })
+  getEngagementItem(@Param('itemId', MongoIdValidationPipe) itemId: string) {
+    return this._service.getEngagement(itemId);
+  }
+
+  @Post('')
+  @ApiCreatedResponse({ type: EngagementResponseDto })
+  createEngagementItem(@Body() dto: GenerateEngagementDto) {
+    return this._service.generateEngagement(dto);
+  }
+
+  // TODO: replace 'system' with current userId
+  @Put('response/:itemId')
+  @ApiOkResponse({ type: EngagementResponseDto })
+  updateResponse(
+    @Param('itemId', MongoIdValidationPipe) itemId: string,
+    @Body() dto: ResponseEngagementDto,
+  ) {
+    return this._service.updateEngagement(itemId, dto, 'system');
+  }
+}

--- a/backend/src/engagements/engagements.controller.ts
+++ b/backend/src/engagements/engagements.controller.ts
@@ -12,8 +12,11 @@ export class EngagementsController {
   constructor(private readonly _service: EngagementService) {}
 
   @Get('lead/:leadId')
-  getEngagementsByid(@Param('leadId', MongoIdValidationPipe) leadId: string) {
-    return this._service.getEngagements(leadId);
+  @ApiOkResponse({ type: [EngagementResponseDto] })
+  getEngagementsByLeadId(
+    @Param('leadId', MongoIdValidationPipe) leadId: string,
+  ) {
+    return this._service.getEngagementsByLeadId(leadId);
   }
 
   @Get(':itemId')

--- a/backend/src/engagements/engagements.module.ts
+++ b/backend/src/engagements/engagements.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { EngagementsController } from './engagements.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { LeadsModule } from 'src/leads/leads.module';
+import { Engagements, EngagementsSchema } from './schema/engagements.schema';
+import { EngagementService } from './engagements.service';
+import { EngagementsRepository } from './engagements.repository';
+
+@Module({
+  controllers: [EngagementsController],
+  imports: [
+    LeadsModule,
+    MongooseModule.forFeature([
+      {
+        name: Engagements.name,
+        schema: EngagementsSchema,
+      },
+    ]),
+  ],
+  providers: [EngagementService, EngagementsRepository],
+})
+export class EngagementsModule {}

--- a/backend/src/engagements/engagements.module.ts
+++ b/backend/src/engagements/engagements.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { EngagementsController } from './engagements.controller';
 import { MongooseModule } from '@nestjs/mongoose';
 import { LeadsModule } from 'src/leads/leads.module';
@@ -9,7 +9,7 @@ import { EngagementsRepository } from './engagements.repository';
 @Module({
   controllers: [EngagementsController],
   imports: [
-    LeadsModule,
+    forwardRef(() => LeadsModule),
     MongooseModule.forFeature([
       {
         name: Engagements.name,
@@ -18,5 +18,6 @@ import { EngagementsRepository } from './engagements.repository';
     ]),
   ],
   providers: [EngagementService, EngagementsRepository],
+  exports: [EngagementService],
 })
 export class EngagementsModule {}

--- a/backend/src/engagements/engagements.repository.ts
+++ b/backend/src/engagements/engagements.repository.ts
@@ -22,8 +22,21 @@ export class EngagementsRepository implements IEngagementsRepository {
     return engagements.save();
   }
 
-  async findEngagementsByLeadId(leadId: string): Promise<Engagements[]> {
-    return this.engagementsModel.find({ lead: leadId }).exec();
+  async findEngagementsByLeadId(
+    leadId: string,
+    take: number = 10,
+    page: number = 1,
+  ): Promise<Engagements[]> {
+    return this.engagementsModel
+      .find({ lead: leadId })
+      .skip((page - 1) * take)
+      .sort({ _id: 1 })
+      .limit(take)
+      .exec();
+  }
+
+  async countEngagementsById(leadId: string): Promise<number> {
+    return this.engagementsModel.countDocuments({ lead: leadId }).exec();
   }
 
   async findEngagement(id: string): Promise<Engagements> {

--- a/backend/src/engagements/engagements.repository.ts
+++ b/backend/src/engagements/engagements.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Engagements } from './schema/engagements.schema';
+import { IEngagementsRepository } from './interfaces/engagements.repository.int';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+
+@Injectable()
+export class EngagementsRepository implements IEngagementsRepository {
+  constructor(
+    @InjectModel(Engagements.name)
+    private readonly engagementsModel: Model<Engagements>,
+  ) {}
+
+  async createEngagement(
+    createHistoryDto: GenerateEngagementDto,
+  ): Promise<Engagements> {
+    const engagements = new this.engagementsModel({
+      ...createHistoryDto,
+      lead: createHistoryDto.lead_id,
+    });
+    return engagements.save();
+  }
+
+  async findEngagementsByLeadId(leadId: string): Promise<Engagements[]> {
+    return this.engagementsModel.find({ lead: leadId }).exec();
+  }
+
+  async findEngagement(id: string): Promise<Engagements> {
+    return this.engagementsModel.findOne({ _id: id });
+  }
+
+  async updateEngagement(
+    id: string,
+    updateData: Partial<GenerateEngagementDto>,
+  ): Promise<Engagements> {
+    return this.engagementsModel
+      .findByIdAndUpdate(id, updateData, { new: true })
+      .exec();
+  }
+
+  async deleteEngagement(id: string): Promise<boolean> {
+    const result = await this.engagementsModel.findByIdAndDelete(id).exec();
+    return !!result;
+  }
+}

--- a/backend/src/engagements/engagements.service.ts
+++ b/backend/src/engagements/engagements.service.ts
@@ -1,5 +1,7 @@
 import {
   BadRequestException,
+  forwardRef,
+  Inject,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -19,17 +21,20 @@ export class EngagementService implements IEngagementService {
 
   constructor(
     private readonly _repository: EngagementsRepository,
+    @Inject(forwardRef(() => LeadsService))
     private readonly _leadService: LeadsService,
   ) {}
 
   async generateEngagement(
     generateEngagementDto: GenerateEngagementDto,
+    userId?: string,
   ): Promise<Engagements> {
     try {
       await this._leadService.findById(generateEngagementDto.lead_id);
-      const engagementsItem = await this._repository.createEngagement(
-        generateEngagementDto,
-      );
+      const engagementsItem = await this._repository.createEngagement({
+        ...generateEngagementDto,
+        created_by: userId ? userId : 'system',
+      });
       return engagementsItem;
     } catch (error) {
       this.logger.error('Error at creating', error.stack);

--- a/backend/src/engagements/engagements.service.ts
+++ b/backend/src/engagements/engagements.service.ts
@@ -1,0 +1,91 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { IEngagementService } from './interfaces/engagements.service.int';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+import { Engagements } from './schema/engagements.schema';
+import { EngagementsRepository } from './engagements.repository';
+import { UpdateEngagementDto } from './dto/update-engagement.dto';
+import { LeadsService } from '../leads/leads.service';
+
+@Injectable()
+export class EngagementService implements IEngagementService {
+  private readonly logger = new Logger('EngagementsService');
+
+  constructor(
+    private readonly _repository: EngagementsRepository,
+    private readonly _leadService: LeadsService,
+  ) {}
+
+  async generateEngagement(
+    generateEngagementDto: GenerateEngagementDto,
+  ): Promise<Engagements> {
+    try {
+      await this._leadService.findById(generateEngagementDto.lead_id);
+      const engagementsItem = await this._repository.createEngagement(
+        generateEngagementDto,
+      );
+      return engagementsItem;
+    } catch (error) {
+      this.logger.error('Error at creating', error.stack);
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException('Lead not found');
+      }
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async getEngagements(leadId: string): Promise<Engagements[]> {
+    try {
+      await this._leadService.findById(leadId);
+      const engagements =
+        await this._repository.findEngagementsByLeadId(leadId);
+      return engagements;
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException('Lead not found');
+      }
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async getEngagement(itemId: string): Promise<Engagements> {
+    try {
+      const engagementsItem = await this._repository.findEngagement(itemId);
+      if (!engagementsItem) {
+        throw new NotFoundException();
+      }
+      return engagementsItem;
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException('Engagement not found');
+      }
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async updateEngagement(
+    itemId: string,
+    dto: UpdateEngagementDto,
+    userId: string,
+  ): Promise<Engagements> {
+    await this.getEngagement(itemId);
+    const newData = { ...dto, updated_by: userId };
+    try {
+      const leadUpdated = await this._repository.updateEngagement(
+        itemId,
+        newData,
+      );
+      return leadUpdated;
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      throw new BadRequestException();
+    }
+  }
+}

--- a/backend/src/engagements/engagements.service.ts
+++ b/backend/src/engagements/engagements.service.ts
@@ -39,7 +39,7 @@ export class EngagementService implements IEngagementService {
     }
   }
 
-  async getEngagements(leadId: string): Promise<Engagements[]> {
+  async getEngagementsByLeadId(leadId: string): Promise<Engagements[]> {
     try {
       await this._leadService.findById(leadId);
       const engagements =

--- a/backend/src/engagements/interfaces/engagements.repository.int.ts
+++ b/backend/src/engagements/interfaces/engagements.repository.int.ts
@@ -5,7 +5,12 @@ export interface IEngagementsRepository {
   createEngagement(
     createHistoryDto: GenerateEngagementDto,
   ): Promise<Engagements>;
-  findEngagementsByLeadId(leadId: string): Promise<Engagements[]>;
+  findEngagementsByLeadId(
+    leadId: string,
+    take?: number,
+    cursor?: number,
+  ): Promise<Engagements[]>;
+  countEngagementsById(leadId: string): Promise<number>;
   findEngagement(id: string): Promise<Engagements>;
   updateEngagement(
     id: string,

--- a/backend/src/engagements/interfaces/engagements.repository.int.ts
+++ b/backend/src/engagements/interfaces/engagements.repository.int.ts
@@ -1,0 +1,15 @@
+import { GenerateEngagementDto } from '../dto/generate-engagement.dto';
+import { Engagements } from '../schema/engagements.schema';
+
+export interface IEngagementsRepository {
+  createEngagement(
+    createHistoryDto: GenerateEngagementDto,
+  ): Promise<Engagements>;
+  findEngagementsByLeadId(leadId: string): Promise<Engagements[]>;
+  findEngagement(id: string): Promise<Engagements>;
+  updateEngagement(
+    id: string,
+    updateData: Partial<GenerateEngagementDto>,
+  ): Promise<Engagements>;
+  deleteEngagement(id: string): Promise<boolean>;
+}

--- a/backend/src/engagements/interfaces/engagements.service.int.ts
+++ b/backend/src/engagements/interfaces/engagements.service.int.ts
@@ -1,3 +1,4 @@
+import { PaginationResponseDto } from 'src/common/dtos/pagination.dto';
 import { GenerateEngagementDto } from '../dto/generate-engagement.dto';
 import { UpdateEngagementDto } from '../dto/update-engagement.dto';
 import { Engagements } from '../schema/engagements.schema';
@@ -7,7 +8,9 @@ export interface IEngagementService {
     generateEngagementItemDto: GenerateEngagementDto,
   ): Promise<Engagements>;
 
-  getEngagementsByLeadId(leadId: string): Promise<Engagements[]>;
+  getEngagementsByLeadId(
+    leadId: string,
+  ): Promise<PaginationResponseDto<Engagements>>;
 
   getEngagement(itemId: string): Promise<Engagements>;
 

--- a/backend/src/engagements/interfaces/engagements.service.int.ts
+++ b/backend/src/engagements/interfaces/engagements.service.int.ts
@@ -1,0 +1,19 @@
+import { GenerateEngagementDto } from '../dto/generate-engagement.dto';
+import { UpdateEngagementDto } from '../dto/update-engagement.dto';
+import { Engagements } from '../schema/engagements.schema';
+
+export interface IEngagementService {
+  generateEngagement(
+    generateEngagementItemDto: GenerateEngagementDto,
+  ): Promise<Engagements>;
+
+  getEngagements(leadId: string): Promise<Engagements[]>;
+
+  getEngagement(itemId: string): Promise<Engagements>;
+
+  updateEngagement(
+    itemId: string,
+    dto: UpdateEngagementDto,
+    userId: string,
+  ): Promise<Engagements>;
+}

--- a/backend/src/engagements/interfaces/engagements.service.int.ts
+++ b/backend/src/engagements/interfaces/engagements.service.int.ts
@@ -7,7 +7,7 @@ export interface IEngagementService {
     generateEngagementItemDto: GenerateEngagementDto,
   ): Promise<Engagements>;
 
-  getEngagements(leadId: string): Promise<Engagements[]>;
+  getEngagementsByLeadId(leadId: string): Promise<Engagements[]>;
 
   getEngagement(itemId: string): Promise<Engagements>;
 

--- a/backend/src/engagements/schema/engagements.schema.ts
+++ b/backend/src/engagements/schema/engagements.schema.ts
@@ -9,6 +9,7 @@ export type EngagementsDocument = HydratedDocument<Engagements>;
 
 @Schema({ timestamps: true })
 export class Engagements {
+  readonly _id?: string;
   @Prop({
     type: mongoose.Schema.Types.ObjectId,
     ref: Leads.name,

--- a/backend/src/engagements/schema/engagements.schema.ts
+++ b/backend/src/engagements/schema/engagements.schema.ts
@@ -7,7 +7,7 @@ import { EngagementResponseDto } from '../dto/response-engagement.dto';
 
 export type EngagementsDocument = HydratedDocument<Engagements>;
 
-@Schema()
+@Schema({ timestamps: true })
 export class Engagements {
   @Prop({
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/src/engagements/schema/engagements.schema.ts
+++ b/backend/src/engagements/schema/engagements.schema.ts
@@ -1,0 +1,69 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { plainToInstance } from 'class-transformer';
+import mongoose, { HydratedDocument, Types } from 'mongoose';
+import { LEAD_CONTACT_TYPES } from '../engagements.constants';
+import { Leads } from '../../leads/schema/leads.model';
+import { EngagementResponseDto } from '../dto/response-engagement.dto';
+
+export type EngagementsDocument = HydratedDocument<Engagements>;
+
+@Schema()
+export class Engagements {
+  @Prop({
+    type: mongoose.Schema.Types.ObjectId,
+    ref: Leads.name,
+    required: true,
+  })
+  lead: Leads;
+  @Prop({
+    type: String,
+    required: true,
+    enum: LEAD_CONTACT_TYPES,
+  })
+  contact_type: string;
+  @Prop({
+    type: Date,
+    required: true,
+  })
+  contact_date: Date;
+  @Prop({
+    type: String,
+    required: true,
+    trim: true,
+  })
+  subject: string;
+  @Prop({
+    type: String,
+    required: true,
+    trim: true,
+  })
+  detail: string;
+  @Prop({
+    type: String,
+    required: false,
+    trim: true,
+  })
+  response?: string;
+  @Prop({
+    type: String,
+    required: true,
+    default: 'system',
+  })
+  created_by: string;
+  @Prop({
+    type: Types.ObjectId,
+    required: false,
+  })
+  updated_by?: string;
+}
+
+export const EngagementsSchema = SchemaFactory.createForClass(Engagements).set(
+  'toJSON',
+  {
+    transform: (_, ret) => {
+      return plainToInstance(EngagementResponseDto, ret, {
+        excludeExtraneousValues: true,
+      });
+    },
+  },
+);

--- a/backend/src/leads/leads.module.ts
+++ b/backend/src/leads/leads.module.ts
@@ -24,6 +24,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     }),
   ],
   controllers: [LeadsController],
-  providers: [LeadsService]
+  providers: [LeadsService],
+  exports: [LeadsService]
 })
 export class LeadsModule {}

--- a/backend/src/leads/schema/leads.model.ts
+++ b/backend/src/leads/schema/leads.model.ts
@@ -12,12 +12,12 @@ export class Leads {
     })
     fullname: string;
 
-    @Prop({
-        type: [mongoose.Schema.Types.ObjectId],
-        required: false,
-        ref: 'contacts'
-    })
-    contact_id: Types.ObjectId[];
+    // @Prop({
+    //     type: [mongoose.Schema.Types.ObjectId],
+    //     required: false,
+    //     ref: 'engegements'
+    // })
+    // contact_id: Types.ObjectId[];
 
     @Prop({
         type: String,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -25,10 +25,14 @@ async function bootstrap() {
       'playAttentionToken',
     )
     .build();
-  
+
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+    }),
+  );
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
**UPDATE**
- `@nest/swagger` version to avoid vulnerabilities in packages
- `LeadsModule` to export `LeadsService`. Used in EngagementsModule
- `LeadsSchema` to comment relation with contacts. Sorry don't know what to do with that.
- `VaidationPipes` in main file to whitelist.

**ADD**
- Engegament module files